### PR TITLE
Fix Error in ANSI sequence parsing.

### DIFF
--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -214,9 +214,9 @@ class Console {
     _adapter.echoMode = em;
 
     var str = new String.fromCharCodes(bytes);
+    str = str.substring(str.lastIndexOf('[') + 1, str.length - 1);
 
-    List<int> parts = new List.from(
-      str.substring(2, str.length - 1)
+    List<int> parts = new List.from(str
         .split(";")
         .map((it) => int.parse(it))
     ).toList();


### PR DESCRIPTION
- Sometimes the last opening square bracket is not removed from the sequence.
  This fixes that by cutting the prefix of the string up to the last bracket
