### PR TITLE
fix: add Completer's type

### DIFF
--- a/lib/src/prompt.dart
+++ b/lib/src/prompt.dart
@@ -196,7 +196,7 @@ class Prompter {
   }
 
   Future<String> prompt({ResponseChecker checker}) {
-    var completer = new Completer();
+    var completer = new Completer<String>();
 
     var doAsk;
     doAsk = () {


### PR DESCRIPTION
Was receiving the following error:
type 'Future<dynamic>' is not a subtype of type 'Future<String>'