### PR TITLE
Upgrade pkg:test dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,10 +5,10 @@ description: Console Power Library
 homepage: https://github.com/DirectMyFile/console.dart
 
 environment:
-  sdk: '>=2.0.0-dev.61 <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   vector_math: ^2.0.7
 
 dev_dependencies:
-  test: '>=0.12.0 <0.13.0'
+  test: ^1.0.0


### PR DESCRIPTION
Below 1.0, `pkg:test` doesn’t work with Dart 2.0.0 proper.