### PR TITLE
Prompter Update

### DIFF
--- a/lib/src/prompt.dart
+++ b/lib/src/prompt.dart
@@ -170,13 +170,13 @@ class Prompter {
   bool askSync({List<String> positive = const []}) {
     var answer = promptSync();
     return _YES_RESPONSES.contains(answer.toLowerCase()) ||
-        positive.contains(message.toLowerCase());
+        positive.contains(answer.toLowerCase());
   }
 
   Future<bool> ask({List<String> positive = const []}) {
     return prompt().then((answer) {
       return _YES_RESPONSES.contains(answer.toLowerCase()) ||
-          positive.contains(message.toLowerCase());
+          positive.contains(answer.toLowerCase());
     });
   }
 


### PR DESCRIPTION
The `positive` argument to the `Prompter.ask` and `Prompter.askSync` methods are evaluating against the prompt message instead of the answer. This changes the argument to be evaluated against the answer.