### PR TITLE
added 'ESC' and 'ENTER' keys to use with handlers

### DIFF
--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -1,33 +1,36 @@
 part of console;
 
 abstract class KeyCode {
-  static const String UP = "${Console.ANSI_ESCAPE}A";
-  static const String DOWN = "${Console.ANSI_ESCAPE}B";
-  static const String RIGHT = "${Console.ANSI_ESCAPE}C";
-  static const String LEFT = "${Console.ANSI_ESCAPE}D";
+  static const String UP = '${Console.ANSI_ESCAPE}A';
+  static const String DOWN = '${Console.ANSI_ESCAPE}B';
+  static const String RIGHT = '${Console.ANSI_ESCAPE}C';
+  static const String LEFT = '${Console.ANSI_ESCAPE}D';
 
-  static const String HOME = "${Console.ANSI_ESCAPE}H";
-  static const String END = "${Console.ANSI_ESCAPE}F";
+  static const String HOME = '${Console.ANSI_ESCAPE}H';
+  static const String END = '${Console.ANSI_ESCAPE}F';
 
-  static const String F1 = "${Console.ANSI_ESCAPE}M";
-  static const String F2 = "${Console.ANSI_ESCAPE}N";
-  static const String F3 = "${Console.ANSI_ESCAPE}O";
-  static const String F4 = "${Console.ANSI_ESCAPE}P";
-  static const String F5 = "${Console.ANSI_ESCAPE}Q";
-  static const String F6 = "${Console.ANSI_ESCAPE}R";
-  static const String F7 = "${Console.ANSI_ESCAPE}S";
-  static const String F8 = "${Console.ANSI_ESCAPE}T";
-  static const String F9 = "${Console.ANSI_ESCAPE}U";
-  static const String F10 = "${Console.ANSI_ESCAPE}V";
-  static const String F11 = "${Console.ANSI_ESCAPE}W";
-  static const String F12 = "${Console.ANSI_ESCAPE}X";
+  static const String F1 = '${Console.ANSI_ESCAPE}M';
+  static const String F2 = '${Console.ANSI_ESCAPE}N';
+  static const String F3 = '${Console.ANSI_ESCAPE}O';
+  static const String F4 = '${Console.ANSI_ESCAPE}P';
+  static const String F5 = '${Console.ANSI_ESCAPE}Q';
+  static const String F6 = '${Console.ANSI_ESCAPE}R';
+  static const String F7 = '${Console.ANSI_ESCAPE}S';
+  static const String F8 = '${Console.ANSI_ESCAPE}T';
+  static const String F9 = '${Console.ANSI_ESCAPE}U';
+  static const String F10 = '${Console.ANSI_ESCAPE}V';
+  static const String F11 = '${Console.ANSI_ESCAPE}W';
+  static const String F12 = '${Console.ANSI_ESCAPE}X';
 
-  static const String INS = "${Console.ANSI_ESCAPE}2~";
-  static const String DEL = "${Console.ANSI_ESCAPE}3~";
-  static const String PAGE_UP = "${Console.ANSI_ESCAPE}5~";
-  static const String PAGE_DOWN = "${Console.ANSI_ESCAPE}6~";
+  static const String INS = '${Console.ANSI_ESCAPE}2~';
+  static const String DEL = '${Console.ANSI_ESCAPE}3~';
+  static const String PAGE_UP = '${Console.ANSI_ESCAPE}5~';
+  static const String PAGE_DOWN = '${Console.ANSI_ESCAPE}6~';
 
-  static const String SPACE = " ";
+  static const String SPACE = ' ';
+
+  static const String ESC = '\u001b';
+  static const String ENTER = '\u000a';
 }
 
 /// API for the Keyboard
@@ -49,7 +52,7 @@ class Keyboard {
       Console.adapter.byteStream().asBroadcastStream().map((bytes) {
         var it = ascii.decode(bytes);
         var original = bytes;
-        var code = it.replaceAll(Console.ANSI_CODE, "");
+        var code = it.replaceAll(Console.ANSI_CODE, '');
 
         if (code.isNotEmpty) {
           code = code.substring(1);
@@ -80,7 +83,7 @@ class Keyboard {
       if (Platform.isMacOS) {
         Console.moveCursorBack(1);
       } else {
-        stdout.write("\b \b");
+        stdout.write('\b \b');
         return;
       }
     }


### PR DESCRIPTION
changed " -> ' to follow Dart's 'prefer single quotes'

ESC and ENTER are commonly used in apps to control things, so I added them to the KeyCode class.
They use unicode instead of ANSI escapes, but still are picked up by the listeners.