### PR TITLE
Fix clipboard setContent for macOS

### DIFF
--- a/lib/src/clipboard.dart
+++ b/lib/src/clipboard.dart
@@ -26,7 +26,7 @@ class OSXClipboard implements Clipboard {
 
   @override
   void setContent(String content) {
-    Process.start('/usr/bin/pbpaste', []).then((process) {
+    Process.start('/usr/bin/pbcopy', []).then((process) {
       process.stdin.write(content);
       process.stdin.close();
     });


### PR DESCRIPTION
macOS uses pbcopy for copying and pbpaste for pasting.
This MR fixes the `setContent` method for macOS