### PR TITLE
Fix DrawingCanvas.unset to properly clear pixels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+- DrawingCanvas unset fix (properly clears pixels now)
+
 ## 4.1.0
 
 - Null Safety

--- a/lib/src/drawing_canvas.dart
+++ b/lib/src/drawing_canvas.dart
@@ -58,7 +58,7 @@ class DrawingCanvas {
 
   void unset(int x, int y) {
     _doIt(x, y, (coord, mask) {
-      content[coord] &= mask;
+      content[coord] &= ~mask;
     });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: console
-version: 4.1.0
+version: 4.1.1
 author: Kenneth Endfinger <kaendfinger@gmail.com>
 description: A library for common features required by console applications, including color formatting, keyboard input, and progress bars. 
 homepage: https://github.com/DirectMyFile/console.dart
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   vector_math: ^2.1.0

--- a/test/drawing_canvas_test.dart
+++ b/test/drawing_canvas_test.dart
@@ -1,0 +1,56 @@
+import 'package:console/console.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('draws top left block', () {
+    final canvas = DrawingCanvas(4, 4);
+    canvas.set(0, 0);
+    final actual = canvas.frame('');
+    expect(actual, equals('⠁ '));
+  });
+
+  test('draws top right block', () {
+    final canvas = DrawingCanvas(4, 4);
+    canvas.set(1, 0);
+    final actual = canvas.frame('');
+    expect(actual, equals('⠈ '));
+  });
+
+  test('draws bottom block', () {
+    final canvas = DrawingCanvas(4, 4);
+    canvas.set(0, 2);
+    canvas.set(1, 2);
+    final actual = canvas.frame('');
+    expect(actual, equals('⠤ '));
+  });
+
+  test('draws full block', () {
+    final canvas = DrawingCanvas(4, 4);
+    canvas.set(0, 0);
+    canvas.set(1, 0);
+    canvas.set(0, 1);
+    canvas.set(1, 1);
+    canvas.set(0, 2);
+    canvas.set(1, 2);
+    final actual = canvas.frame('');
+    expect(actual, equals('⠿ '));
+  });
+
+  test('clears top left block - clear before set', () {
+    final canvas = DrawingCanvas(4, 4);
+    canvas.set(0, 0);
+    canvas.unset(0, 0);
+    canvas.set(1, 0);
+    final actual = canvas.frame('');
+    expect(actual, equals('⠈ '));
+  });
+
+  test('clears top left block - clear after set', () {
+    final canvas = DrawingCanvas(4, 4);
+    canvas.set(0, 0);
+    canvas.set(1, 0);
+    canvas.unset(0, 0);
+    final actual = canvas.frame('');
+    expect(actual, equals('⠈ '));
+  });
+}


### PR DESCRIPTION
Not sure if this is still maintained... ^^

But here's a fix for using the DrawingCanvas without calling clear before every frame. Obviously not a big deal. But just in case this is of interest to someone. I just happened to stumble across this bug...

Also: No idea about updating pubspec etc... Feel free to ignore and/or close this PR...

Cheers, Daniel